### PR TITLE
Migrate Prisma client imports to @prisma/client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
 COPY --from=builder --chown=nodejs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nodejs:nodejs /app/package.json ./package.json
 COPY --from=builder --chown=nodejs:nodejs /app/prisma ./prisma
-COPY --from=builder --chown=nodejs:nodejs /app/generated ./generated
 
 # Copy JWT keys generated in builder stage
 COPY --from=builder --chown=nodejs:nodejs /app/keys ./keys

--- a/docs/DATABASE_MIGRATION_GUIDE.md
+++ b/docs/DATABASE_MIGRATION_GUIDE.md
@@ -202,7 +202,7 @@ npx prisma migrate dev --name add_username_field
 Create a seed script `prisma/seed.ts`:
 
 ```typescript
-import { PrismaClient, Role } from '../generated/prisma';
+import { PrismaClient, Role } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException, ConflictException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
-import { User } from '../../generated/prisma';
+import { User } from '@prisma/client';
 import { CreateUserDto } from '../users/dto/create-user.dto';
 import { LoginDto } from './dto/login.dto';
 import { UserWithRoles } from '../users/users.repository';

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common';
-import { PrismaClient } from '../../generated/prisma';
+import { PrismaClient } from '@prisma/client';
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { User, Role, UserRole, Prisma } from '../../generated/prisma';
+import { User, Role, UserRole, Prisma } from '@prisma/client';
 import { CreateUserDto } from './dto/create-user.dto';
 
 export type UserWithRoles = User & { roles: UserRole[] };

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
-import { User } from '../../generated/prisma';
+import { User } from '@prisma/client';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UsersRepository, UserWithRoles } from './users.repository';
 


### PR DESCRIPTION
Updated all imports from the local generated Prisma client to use the official @prisma/client package. Removed custom output directory from schema.prisma and related Dockerfile copy command. Updated documentation to reflect the new import path.